### PR TITLE
Update dependencies and add workflow dispatch to test CI.

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -45,7 +45,7 @@ jobs:
         # https://github.com/Codeception/module-asserts
         # https://packagist.org/packages/codeception/util-universalframework
         # https://github.com/Codeception/module-rest
-        if: ${{ matrix.php == '8.0' }}
+        if: ${{ matrix.php >= '8.0' }}
         run: composer run-codeception -- -- --coverage --coverage-xml
 
       - name: Run PHPUnit Tests w/ Docker.

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -34,27 +34,20 @@ jobs:
       - name: Install Dependencies
         run: composer install
 
-      - name: Spin up Docker
-        run: docker-compose up -d
-
       # - name: Run Codeception Tests w/ Docker.
       #   run: composer run-codeception -- -- --coverage --coverage-xml
 
       - name: Run PHPUnit Tests w/ Docker.
         run: composer run-phpunit -- -- --coverage-text
 
-      - name: Push Codecoverage to Coveralls.io
-        env:
-          COVERALLS_RUN_LOCALLY: 1
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: |
-          docker-compose run --rm \
-          --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase \
-          --user $(id -u) \
-          -e COVERALLS_RUN_LOCALLY=1 -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
-          wordpress \
-          vendor/bin/php-coveralls -v
-
-      - name: Spin down Docker
-        if: always()
-        run: docker-compose down
+      # - name: Push Codecoverage to Coveralls.io
+      #   env:
+      #     COVERALLS_RUN_LOCALLY: 1
+      #     COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      #   run: |
+      #     docker-compose run --rm \
+      #     --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase \
+      #     --user $(id -u) \
+      #     -e COVERALLS_RUN_LOCALLY=1 -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
+      #     wordpress \
+      #     vendor/bin/php-coveralls -v

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -1,6 +1,7 @@
 name: continuous_integration
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 4 * * 5'
   push:

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -2,11 +2,6 @@ name: continuous_integration
 
 on:
   workflow_dispatch:
-    inputs:
-      push-coverage:
-        description: "Boolean flag to turn on/off the coveralls.io step"
-        required: false
-        default: "true"
   schedule:
     - cron: "0 4 * * 5"
   push:
@@ -46,7 +41,6 @@ jobs:
         run: composer run-phpunit -- -- --coverage-text
 
       - name: Push Codecoverage to Coveralls.io
-        if: ${{ github.event.inputs.push-coverage == 'true' }}
         env:
           COVERALLS_RUN_LOCALLY: 1
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -35,6 +35,7 @@ jobs:
         run: composer install
 
       - name: Run Codeception Tests w/ Docker.
+        if: ${{ matrix.php == '8.0' }}
         run: composer run-codeception -- -- --coverage --coverage-xml
 
       - name: Run PHPUnit Tests w/ Docker.

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -2,6 +2,11 @@ name: continuous_integration
 
 on:
   workflow_dispatch:
+    inputs:
+      push-coverage:
+        description: "Boolean flag to turn on/off the coveralls.io step"
+        required: false
+        default: "false"
   schedule:
     - cron: "0 4 * * 5"
   push:
@@ -17,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["7.3", "7.4", "8.0"]
+        php: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
       fail-fast: false
     name: Make sure that the WPGraphQLTestCase works!!!
 
@@ -35,20 +40,26 @@ jobs:
         run: composer install
 
       - name: Run Codeception Tests w/ Docker.
+        # Codeception requires PHP version >= 8.0
+        # See:
+        # https://github.com/Codeception/module-asserts
+        # https://packagist.org/packages/codeception/util-universalframework
+        # https://github.com/Codeception/module-rest
         if: ${{ matrix.php == '8.0' }}
         run: composer run-codeception -- -- --coverage --coverage-xml
 
       - name: Run PHPUnit Tests w/ Docker.
         run: composer run-phpunit -- -- --coverage-text
 
-      # - name: Push Codecoverage to Coveralls.io
-      #   env:
-      #     COVERALLS_RUN_LOCALLY: 1
-      #     COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      #   run: |
-      #     docker-compose run --rm \
-      #     --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase \
-      #     --user $(id -u) \
-      #     -e COVERALLS_RUN_LOCALLY=1 -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
-      #     wordpress \
-      #     vendor/bin/php-coveralls -v
+      - name: Push Codecoverage to Coveralls.io
+        if: ${{ github.event.inputs.push-coverage == 'true' }}
+        env:
+          COVERALLS_RUN_LOCALLY: 1
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          docker-compose run --rm \
+          --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase \
+          --user $(id -u) \
+          -e COVERALLS_RUN_LOCALLY=1 -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
+          wordpress \
+          vendor/bin/php-coveralls -v

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -31,11 +31,11 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: json, mbstring
 
-      - name: Spin up Docker
-        run: docker-compose up -d
-
       - name: Install Dependencies
         run: composer install
+
+      - name: Spin up Docker
+        run: docker-compose up -d
 
       - name: Run Codeception Tests w/ Docker.
         run: composer run-codeception -- -- --coverage --coverage-xml

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -31,7 +31,7 @@ jobs:
           path: .env.testing
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php
         with:
           php-version: ${{ matrix.php }}
           extensions: json, mbstring

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Spin up Docker
         run: docker-compose up -d
 
-      - name: Run Codeception Tests w/ Docker.
-        run: composer run-codeception -- -- --coverage --coverage-xml
+      # - name: Run Codeception Tests w/ Docker.
+      #   run: composer run-codeception -- -- --coverage --coverage-xml
 
       - name: Run PHPUnit Tests w/ Docker.
         run: composer run-phpunit -- -- --coverage-text

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -25,13 +25,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Load .env.testing file
-        uses: falti/dotenv-action@v2
-        with:
-          path: .env.testing
+      - name: Import environment variables from .env.testing
+        shell: bash
+        run: cat .env.testing >> $GITHUB_ENV
 
       - name: Install PHP
-        uses: shivammathur/setup-php
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: json, mbstring

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install Dependencies
         run: composer install
 
-      # - name: Run Codeception Tests w/ Docker.
-      #   run: composer run-codeception -- -- --coverage --coverage-xml
+      - name: Run Codeception Tests w/ Docker.
+        run: composer run-codeception -- -- --coverage --coverage-xml
 
       - name: Run PHPUnit Tests w/ Docker.
         run: composer run-phpunit -- -- --coverage-text

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -3,7 +3,7 @@ name: continuous_integration
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 4 * * 5'
+    - cron: "0 4 * * 5"
   push:
     branches:
       - master
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.3', '7.4', '8.0' ]
+        php: ["7.3", "7.4", "8.0"]
       fail-fast: false
     name: Make sure that the WPGraphQLTestCase works!!!
     steps:
@@ -30,27 +30,13 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: json, mbstring
 
-      - name: Install Codeception dependencies
-        run: |
-          composer install --ignore-platform-reqs
-          composer require codeception/module-asserts:* \
-            codeception/util-universalframework:* \
-            codeception/module-rest:* \
-            lucatume/wp-browser:^3.1 --ignore-platform-reqs
+      - name: Install Dependencies
+        run: composer install
 
       - name: Run Codeception Tests w/ Docker.
         run: composer run-codeception -- -- --coverage --coverage-xml
 
-      - name: Install PHPUnit dependencies
-        if: ${{ matrix.php != '8.0' }}
-        run: |
-          composer require wp-phpunit/wp-phpunit \
-          yoast/phpunit-polyfills \
-          phpunit/phpunit
-          composer install
-
       - name: Run PHPUnit Tests w/ Docker.
-        if: ${{ matrix.php != '8.0' }}
         run: composer run-phpunit -- -- --coverage-text
 
       - name: Push Codecoverage to Coveralls.io

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -6,7 +6,7 @@ on:
       push-coverage:
         description: "Boolean flag to turn on/off the coveralls.io step"
         required: false
-        default: "false"
+        default: "true"
   schedule:
     - cron: "0 4 * * 5"
   push:

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        php: ["8.1", "8.2", "8.3"]
       fail-fast: false
     name: Make sure that the WPGraphQLTestCase works!!!
 
@@ -40,12 +40,6 @@ jobs:
         run: composer install
 
       - name: Run Codeception Tests w/ Docker.
-        # Codeception requires PHP version >= 8.0
-        # See:
-        # https://github.com/Codeception/module-asserts
-        # https://packagist.org/packages/codeception/util-universalframework
-        # https://github.com/Codeception/module-rest
-        if: ${{ matrix.php >= '8.0' }}
         run: composer run-codeception -- -- --coverage --coverage-xml
 
       - name: Run PHPUnit Tests w/ Docker.

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -25,15 +25,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Import environment variables from .env.testing
-        shell: bash
-        run: cat .env.testing >> $GITHUB_ENV
-
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: json, mbstring
+
+      - name: Spin up Docker
+        run: docker-compose up -d
 
       - name: Install Dependencies
         run: composer install
@@ -55,3 +54,7 @@ jobs:
           -e COVERALLS_RUN_LOCALLY=1 -e COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN \
           wordpress \
           vendor/bin/php-coveralls -v
+
+      - name: Spin down Docker
+        if: always()
+        run: docker-compose down

--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -20,9 +20,15 @@ jobs:
         php: ["7.3", "7.4", "8.0"]
       fail-fast: false
     name: Make sure that the WPGraphQLTestCase works!!!
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Load .env.testing file
+        uses: falti/dotenv-action@v2
+        with:
+          path: .env.testing
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 80,
+  "proseWrap": "always"
+}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,56 @@
 # WPGraphQL TestCase
-![continuous_integration](https://github.com/wp-graphql/wp-graphql-testcase/workflows/continuous_integration/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/wp-graphql/wp-graphql-testcase/badge.svg)](https://coveralls.io/github/wp-graphql/wp-graphql-testcase)
 
-Is a library of tools for testing WPGraphQL APIs, designed for both WPGraphQL and WPGraphQL extension development. Currently the library only consisted of a Codeception Testcase built on top wp-browser's WPTestCase class.
+![continuous_integration](https://github.com/wp-graphql/wp-graphql-testcase/workflows/continuous_integration/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/wp-graphql/wp-graphql-testcase/badge.svg)](https://coveralls.io/github/wp-graphql/wp-graphql-testcase)
+
+Is a library of tools for testing WPGraphQL APIs, designed for both WPGraphQL
+and WPGraphQL extension development. Currently the library only consisted of a
+Codeception Testcase built on top wp-browser's WPTestCase class.
 
 ## Installing
-1. Run `composer require wp-graphql/wp-graphql-testcase` from your project directory in the terminal.
-2. _(Optionally: Codeception only)_ If your didn't already have codeception installed in the project, run `vendor/bin/codecept init wpbrowser`.
-3. To make a test case generate a with `vendor/bin/codecept generate:wpunit wpunit TestName`. Then just change the extending class to `\Tests\WPGraphQL\TestCase\WPGraphQLTestCase` :man_shrugging:
 
-## Going forward
-There are plans to add more to this library, and contribution are greatly appreciated :pray:.
+1. Run `composer require wp-graphql/wp-graphql-testcase` from your project
+   directory in the terminal.
+
+## Codeception Only
+
+1. If your didn't already have codeception installed in the project, run
+   `vendor/bin/codecept init wpbrowser`.
+2. To make a test case generate a with
+   `vendor/bin/codecept generate:wpunit wpunit TestName`. Then just change the
+   extending class to `\Tests\WPGraphQL\TestCase\WPGraphQLTestCase`
+   :man_shrugging:
+
+## Going Forward
+
+There are plans to add more to this library, and contribution are greatly
+appreciated :pray:.
+
+## Contributing
+
+To contribute, fork this repository and open a PR with your requested changes
+back into the main repository.
+
+### Local Development
+
+To develop locally, you need to have Docker and Composer installed.
+
+#### Composer Setup
+
+To ensure you have the necessary local dependencies, first run
+`composer install`.
+
+#### Docker Setup
+
+This project currently uses a `docker-compose.yml` v2 file. To spin this up, run
+`docker-compose up -d`.
+
+#### Local Tests
+
+To run the local tests, use `composer run-phpunit` or
+`composer run-codeception`. You should see the tests pass with output generated
+in the terminal.
 
 ## Contributors
+
 <a href="https://github.com/kidunot89"><img src="https://avatars.githubusercontent.com/u/13604318?v=3" title="kidunot89" width="80" height="80"></a>

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ To run the local tests, use `composer run-phpunit` or
 `composer run-codeception`. You should see the tests pass with output generated
 in the terminal.
 
+#### Test Coverage
+
+The CI process uses [coveralls.io](https://coveralls.io/) to store coverage
+reports. This is available for free for open-source projects, and is required to
+run the CI process. Sign up for free and add your `COVERALLS_REPO_TOKEN` value
+to GitHub Actions secrets.
+
 ## Contributors
 
 <a href="https://github.com/kidunot89"><img src="https://avatars.githubusercontent.com/u/13604318?v=3" title="kidunot89" width="80" height="80"></a>

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "cli": "docker-compose run --rm --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase --user $(id -u) wordpress wait_for_it $TEST_DB -s -t 300 --",
         "codeception": "codecept run wpunit --",
         "phpunit": "phpunit --",
-        "run-codeception": "env TEST_DB=mysql_phpunit:3306 composer cli vendor/bin/codecept run wpunit",
+        "run-codeception": "env TEST_DB=mysql:3306 composer cli vendor/bin/codecept run wpunit",
         "run-phpunit": "env TEST_DB=mysql_phpunit:3306 composer cli vendor/bin/phpunit"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "codeception/module-asserts": "*",
         "codeception/util-universalframework": "*",
         "codeception/module-rest": "*",
-        "lucatume/wp-browser": "^3.1"
+        "lucatume/wp-browser": "^3.1",
+        "php-coveralls/php-coveralls": "2.4.3"
     },
     "scripts": {
         "cli": "docker-compose run --rm --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase --user $(id -u) wordpress wait_for_it $TEST_DB -s -t 300 --",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "cli": "docker-compose run --rm --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase --user $(id -u) wordpress wait_for_it $TEST_DB -s -t 300 --",
         "codeception": "codecept run wpunit --",
         "phpunit": "phpunit --",
-        "run-codeception": "env TEST_DB=mysql:3306 composer cli vendor/bin/codecept run wpunit",
+        "run-codeception": "env TEST_DB=mysql_phpunit:3306 composer cli vendor/bin/codecept run wpunit",
         "run-phpunit": "env TEST_DB=mysql_phpunit:3306 composer cli vendor/bin/phpunit"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,18 @@
     },
     "require-dev": {
         "composer/installers": "^1.9",
-        "johnpbloch/wordpress": "^5.4",
+        "johnpbloch/wordpress": "^6.1",
         "wp-graphql/wp-graphql": "^1.1.8",
         "squizlabs/php_codesniffer": "^3.5",
         "automattic/vipwpcs": "^2.3",
-        "wp-coding-standards/wpcs": "^2.3"
+        "wp-coding-standards/wpcs": "^2.3",
+        "wp-phpunit/wp-phpunit": "^6.3",
+        "yoast/phpunit-polyfills": "^2.0",
+        "phpunit/phpunit": "^9.6",
+        "codeception/module-asserts": "*",
+        "codeception/util-universalframework": "*",
+        "codeception/module-rest": "*",
+        "lucatume/wp-browser": "^3.1"
     },
     "scripts": {
         "cli": "docker-compose run --rm --workdir=/var/www/html/wp-content/plugins/wp-graphql-testcase --user $(id -u) wordpress wait_for_it $TEST_DB -s -t 300 --",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN	pecl install "xdebug-${XDEBUG_VERSION}"; \
 
 # Install PDO MySQL driver.
 RUN docker-php-ext-install \
-    pdo_mysql
+	pdo_mysql
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /usr/local/bin/wait_for_it
 RUN chmod 755 /usr/local/bin/wait_for_it

--- a/local/config/wp-tests-config.php
+++ b/local/config/wp-tests-config.php
@@ -15,8 +15,6 @@ define( 'DB_HOST', 'mysql_phpunit' );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 
-global $table_prefix;
-
 $table_prefix = 'wptests_';
 
 define( 'WP_TESTS_DOMAIN', 'example.org' );

--- a/local/config/wp-tests-config.php
+++ b/local/config/wp-tests-config.php
@@ -15,6 +15,8 @@ define( 'DB_HOST', 'mysql_phpunit' );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 
+global $table_prefix;
+
 $table_prefix = 'wptests_';
 
 define( 'WP_TESTS_DOMAIN', 'example.org' );


### PR DESCRIPTION
## Description

This PR updates the composer dependencies to include PHPUnit, and modifies the minimum version of the `johnpbloch/wordpress` dependency from `5.4` to `6.1`

The reason for the version bump is that the PHPUnit run appears to look for a `wp-includes/class-wpdb.php` file which has been introduced in WP `6.1`. See: https://wordpress.org/support/topic/file-wp-db-php-is-deprecated-since-version-6-1-0/

Since this file was not present in `5.4`, PHPUnit would fail.

## Codeception

Codeception dependencies required version PHP 8.0 or above, so the CI would fail for the 7.2 and 7.3 versions of PHP. See comments for notes.

## Additional Changes

Additionally, a `.prettierrc` file is added with settings to format the `README.md` file with line breaks automatically.